### PR TITLE
fix typos

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -29,7 +29,7 @@ func (m Mode) String() string {
 	return "VIS"
 }
 
-// Driver represents anything that can run selected text. it can be sql conncetion,
+// Driver represents anything that can run selected text. it can be sql connection,
 // or rest client.
 type Driver interface {
 	// Execute thing under cursor: line or seleciton

--- a/search.go
+++ b/search.go
@@ -6,7 +6,7 @@ import (
 	str "github.com/boyter/go-string"
 )
 
-// Move cursor to the next search patten match
+// Move cursor to the next search pattern match
 func SearchNext(ctx Context, pattern string) {
 	defer CmdEnsureCursorVisible(ctx)
 


### PR DESCRIPTION
found via `codespell -L ine,thre,prevend -S runtime`